### PR TITLE
. t test.sh should fail on error

### DIFF
--- a/bash/test.sh
+++ b/bash/test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 echo "test: pass"
 ./verify.sh -t test1 <<< "test 1 approves this message


### PR DESCRIPTION
Added the standard Bash boilerplate. `-e` is fail on error.

## Summary by Sourcery

Build:
- Set the `-e` flag in the test script to enable fail-on-error behavior.