### PR TITLE
. e run CI weekly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
+  schedule:
+    - cron:  '0 3 * * 4'
 
 jobs:
   test:


### PR DESCRIPTION
just in case something external breaks it

## Summary by Sourcery

CI:
- Set up a weekly schedule for the CI.