### PR TITLE
. t add test case for failing exit code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,7 @@ jobs:
       - name: test bash verify.sh
         run: ./test.sh | ./verify.sh -t verify-cli-bash
         working-directory: bash
+
+      - name: failure returns non-zero exit code
+        run: '! (./verify.sh -t failing-test -d echo <<< "input")'
+        working-directory: bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.received*
+bash/failing-test.approved


### PR DESCRIPTION
## Summary by Sourcery

Add a test case to verify that a failing exit code is returned when the verification fails.

CI:
- Verify that failing tests return a non-zero exit code.

Tests:
- Add a test case for failing exit code.